### PR TITLE
Add instructions specific for MangoPi MQ-Pro

### DIFF
--- a/README_D1.txt
+++ b/README_D1.txt
@@ -26,6 +26,12 @@ USB-C (use the OTG port, which can also power the board):
   xfel ddr ddr3; xfel write 0x40000000 ../xv6-d1/kernel/kernel.bin; \\
   xfel exec 0x40000000
 
+- ONLY FOR MANGOPI MQ-PRO: on a MangoPi MQ-Pro, xfel ddr ddr3 does not seem to
+  work, xfel ddr d1 can be used instead:
+
+  xfel ddr d1; xfel write 0x40000000 ../xv6-d1/kernel/kernel.bin; \\
+  xfel exec 0x40000000
+
 - Start a terminal emulator on /dev/ttyUSB0 (or whereever the UART 
   of the D1 is mapped to), parameters 115200 bps, 8N1
 

--- a/README_D1.txt
+++ b/README_D1.txt
@@ -26,8 +26,8 @@ USB-C (use the OTG port, which can also power the board):
   xfel ddr ddr3; xfel write 0x40000000 ../xv6-d1/kernel/kernel.bin; \\
   xfel exec 0x40000000
 
-- ONLY FOR MANGOPI MQ-PRO: on a MangoPi MQ-Pro, xfel ddr ddr3 does not seem to
-  work, xfel ddr d1 can be used instead:
+- ONLY FOR MANGOPI MQ-PRO: on a MangoPi MQ-Pro, xfel ddr ddr3 does
+  not seem to work, xfel ddr d1 can be used instead:
 
   xfel ddr d1; xfel write 0x40000000 ../xv6-d1/kernel/kernel.bin; \\
   xfel exec 0x40000000


### PR DESCRIPTION
Hi, when trying out this operating system on my [MangoPi MQ-Pro](https://mangopi.cc/mangopi_mqpro), I noticed an issue when trying to run the DDR3 RAM init code using `xfel ddr ddr3`, using `xfel ddr d1` did work however.
I don't know if this is specific for the MangoPi MQ-Pro, or if other D1 boards also have this issue. The MangoPi MQ-Pro is the only D1 SBC I have access to. So I added a paragraph to the D1 README specificly and only for the MangoPi MQ-Pro.