### PR TITLE
Fix build error for latest toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ OBJDUMP = $(TOOLPREFIX)objdump
 
 CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb
 CFLAGS += -MD
+CFLAGS += -Wno-incompatible-pointer-types
 CFLAGS += -mcmodel=medany
 CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax
 CFLAGS += -I.

--- a/user/sh.c
+++ b/user/sh.c
@@ -54,6 +54,7 @@ void panic(char*);
 struct cmd *parsecmd(char*);
 
 // Execute cmd.  Never returns.
+__attribute__((noreturn))
 void
 runcmd(struct cmd *cmd)
 {


### PR DESCRIPTION
with latest [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain) the build fails, need to update `Makefile` and `sh.c` to `make fs.img` step pass